### PR TITLE
提取表名BugFix, 补充测试用例

### DIFF
--- a/controllers/extract/extract_tables.go
+++ b/controllers/extract/extract_tables.go
@@ -33,6 +33,23 @@ func removeDuplicateElement(data []string) []string {
 	return result
 }
 
+func removeElement(data, toBeRemoved []string) []string {
+	if toBeRemoved == nil || data == nil {
+		return data
+	}
+	result := make([]string, 0, len(data))
+	temp := map[string]struct{}{}
+	for _, item := range toBeRemoved {
+		temp[item] = struct{}{}
+	}
+	for _, item := range data {
+		if _, ok := temp[item]; !ok {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
 // 返回数据
 type ReturnData struct {
 	Tables []string `json:"tables"` // 表名
@@ -79,7 +96,8 @@ func (c *Checker) Parse() error {
 
 // 提取表结构体
 type ExtractTables struct {
-	Tables []string // 表名
+	Tables            []string // 表名
+	RecursiveCTENames []string // 递归CTE别名
 }
 
 // 迭代select语句
@@ -98,6 +116,14 @@ func (e *ExtractTables) checkSelectItem(node ast.ResultSetNode) {
 		e.checkSelectItem(n.Source)
 	case *ast.TableName:
 		e.Tables = append(e.Tables, n.Name.String())
+	}
+}
+
+func (e *ExtractTables) checkCTEItems(node *ast.WithClause) {
+	if node.IsRecursive {
+		for _, ctE := range node.CTEs {
+			e.RecursiveCTENames = append(e.RecursiveCTENames, ctE.Name.String())
+		}
 	}
 }
 
@@ -136,9 +162,10 @@ func (e *ExtractTables) checkExprItem(expr ast.ExprNode) {
 
 // TraverseStatement
 type TraverseStatement struct {
-	Tables      []string // 表名
-	Type        string   // 语句类型
-	setTypeOnce sync.Once
+	Tables            []string // 表名
+	RecursiveCTENames []string // 递归CTE别名
+	Type              string   // 语句类型
+	setTypeOnce       sync.Once
 }
 
 func (c *TraverseStatement) setType(typ string) {
@@ -155,6 +182,8 @@ func (c *TraverseStatement) Enter(in ast.Node) (ast.Node, bool) {
 		c.setType("SELECT")
 		// 处理WITH语句
 		if stmt.With != nil {
+			e.checkCTEItems(stmt.With)
+			c.RecursiveCTENames = append(c.RecursiveCTENames, e.RecursiveCTENames...)
 			break
 		}
 		// select 1;
@@ -176,9 +205,10 @@ func (c *TraverseStatement) Enter(in ast.Node) (ast.Node, bool) {
 		}
 		c.Tables = append(c.Tables, e.Tables...)
 	case *ast.InsertStmt:
-		c.setType("INSERT")
 		if stmt.IsReplace {
 			c.setType("REPLACE")
+		} else {
+			c.setType("INSERT")
 		}
 		e.checkSelectItem(stmt.Table.TableRefs)
 		e.checkSelectItem(stmt.Select)
@@ -213,7 +243,11 @@ func (c *TraverseStatement) Enter(in ast.Node) (ast.Node, bool) {
 			c.Tables = append(c.Tables, t.NewTable.Name.String())
 		}
 	case *ast.DropTableStmt:
-		c.setType("DROP TABLE")
+		if stmt.IsView {
+			c.setType("DROP VIEW")
+		} else {
+			c.setType("DROP TABLE")
+		}
 		for _, t := range stmt.Tables {
 			c.Tables = append(c.Tables, t.Name.L)
 		}
@@ -231,5 +265,5 @@ func (c *TraverseStatement) Leave(in ast.Node) (ast.Node, bool) {
 func ExtractTablesFromStatement(stmt *ast.StmtNode) ([]string, string) {
 	v := &TraverseStatement{}
 	(*stmt).Accept(v)
-	return removeDuplicateElement(v.Tables), v.Type
+	return removeElement(removeDuplicateElement(v.Tables), v.RecursiveCTENames), v.Type
 }

--- a/controllers/extract/extract_tables.go
+++ b/controllers/extract/extract_tables.go
@@ -115,14 +115,14 @@ func (e *ExtractTables) checkSelectItem(node ast.ResultSetNode) {
 	case *ast.TableSource:
 		e.checkSelectItem(n.Source)
 	case *ast.TableName:
-		e.Tables = append(e.Tables, n.Name.String())
+		e.Tables = append(e.Tables, n.Name.L)
 	}
 }
 
 func (e *ExtractTables) checkCTEItems(node *ast.WithClause) {
 	if node.IsRecursive {
 		for _, ctE := range node.CTEs {
-			e.RecursiveCTENames = append(e.RecursiveCTENames, ctE.Name.String())
+			e.RecursiveCTENames = append(e.RecursiveCTENames, ctE.Name.L)
 		}
 	}
 }
@@ -239,8 +239,8 @@ func (c *TraverseStatement) Enter(in ast.Node) (ast.Node, bool) {
 	case *ast.RenameTableStmt:
 		c.setType("RENAME TABLE")
 		for _, t := range stmt.TableToTables {
-			c.Tables = append(c.Tables, t.OldTable.Name.String())
-			c.Tables = append(c.Tables, t.NewTable.Name.String())
+			c.Tables = append(c.Tables, t.OldTable.Name.L)
+			c.Tables = append(c.Tables, t.NewTable.Name.L)
 		}
 	case *ast.DropTableStmt:
 		if stmt.IsView {

--- a/controllers/extract/extract_tables_test.go
+++ b/controllers/extract/extract_tables_test.go
@@ -234,9 +234,9 @@ func TestChecker_Extract(t *testing.T) {
 			wantRes: []ReturnData{
 				{
 					Tables: []string{
-						"T1",
-						"T2",
-						"T3",
+						"t1",
+						"t2",
+						"t3",
 					},
 					Type:  "INSERT",
 					Query: "INSERT INTO T1 SELECT * FROM T2 WHERE id in (SELECT ID FROM T3)",
@@ -289,7 +289,7 @@ func TestChecker_Extract(t *testing.T) {
 				{
 					Tables: []string{
 						"v_f_players",
-						"PLAYERS",
+						"players",
 					},
 					Type:  "CREATE VIEW",
 					Query: "CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v_F_players` AS select `PLAYERS`.`PLAYERNO`,`PLAYERS`.`NAME`,`PLAYERS`.`SEX`,`PLAYERS`.`PHONENO` from `PLAYERS` where (`PLAYERS`.`SEX` = 'F') WITH CASCADED CHECK OPTION;",

--- a/controllers/extract/extract_tables_test.go
+++ b/controllers/extract/extract_tables_test.go
@@ -129,20 +129,6 @@ func TestChecker_Extract(t *testing.T) {
 			},
 		},
 		{
-			name: "递归的CTE(不包含任何表)",
-			form: forms.ExtractTablesForm{
-				SqlText:   "WITH RECURSIVE cte(a) AS (SELECT 1 UNION SELECT a+1 FROM cte WHERE a < 5) SELECT * FROM cte;",
-				RequestID: "78c25a06-3b34-4ecb-b9dd-7197078873c7",
-			},
-			wantRes: []ReturnData{
-				{
-					Tables: []string{},
-					Type:   "SELECT",
-					Query:  "WITH RECURSIVE cte(a) AS (SELECT 1 UNION SELECT a+1 FROM cte WHERE a < 5) SELECT * FROM cte;",
-				},
-			},
-		},
-		{
 			name: "递归的CTE",
 			form: forms.ExtractTablesForm{
 				SqlText:   "WITH RECURSIVE cte ( node, path ) AS ( SELECT node, '1'  FROM bst WHERE parent IS NULL UNION ALL SELECT bst.node,  CONCAT ( cte.path, '-->', bst.node ) FROM cte JOIN bst ON cte.node = bst.parent) SELECT * FROM cte ORDER BY node;",


### PR DESCRIPTION
## bug1: DROP VIEW 类型错误
```sql
drop view db1.v1;
```
Type解析错误:
Expected: `DROP VIEW`
Got: `DROP TABLE`
因为create table和create view已经区分出来了, 所以drop也应该区分?

## bug2: REPLACE
```sql
REPLACE INTO t1 (id, c1) VALUES(3, 99);
```
Type解析错误:
Expected: `REPLACE`
Got: `INSERT`
[修复INSERT INTO SELECT类型解析错误](https://github.com/lazzyfu/gAudit/pull/1) 引发的bug

## bug3: 递归CTE
```sql
WITH recursive cte ( node, path ) AS
(
       SELECT node,
              '1'
       FROM   bst
       WHERE  parent IS NULL
       UNION ALL
       SELECT bst.node,
                     concat ( cte.path, '-->', bst.node )
       FROM   cte
       JOIN   bst
       ON     cte.node = bst.parent)
SELECT   *
FROM     cte
ORDER BY node;
```
Expected: `[]string{"bst"}`
Got: `[]string{"cte","bst"}`
