### PR TITLE
AlterTableDropTiDBColWithCoveredIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ curl --location --request POST '127.0.0.1:8081/api/v1/extract-tables' \
 ### Python调用接口模板
 > 请根据自己的需求进行封装改造即可
 
-`template/python_api.py`
+文件位置`template/python_api.py`
 
 
 ## 致谢

--- a/controllers/inspect/rule_alter.go
+++ b/controllers/inspect/rule_alter.go
@@ -25,6 +25,10 @@ func AlterTableRules() []Rule {
 			CheckFunc: (*Rule).RuleAlterTableDropColsOrIndexes,
 		},
 		{
+			Hint:      "AlterTable#DropTiDBColWithCoveredIndex检查",
+			CheckFunc: (*Rule).RuleAlterTableDropTiDBColWithCoveredIndex,
+		},
+		{
 			Hint:      "AlterTable#表Options检查",
 			CheckFunc: (*Rule).RuleAlterTableOptions,
 		},
@@ -102,6 +106,13 @@ func (r *Rule) RuleAlterTableDropColsOrIndexes(tistmt *ast.StmtNode) {
 	v := &TraverseAlterTableDropColsOrIndexes{}
 	(*tistmt).Accept(v)
 	LogicAlterTableDropColsOrIndexes(v, r)
+}
+
+// RuleAlterTableDropTiDBColWithCoveredIndex
+func (r *Rule) RuleAlterTableDropTiDBColWithCoveredIndex(tistmt *ast.StmtNode) {
+	v := &TraverseAlterTableDropTiDBColWithCoveredIndex{}
+	(*tistmt).Accept(v)
+	LogicAlterTableDropTiDBColWithCoveredIndex(v, r)
 }
 
 // RuleAlterTableOptions

--- a/controllers/inspect/traverse_alter.go
+++ b/controllers/inspect/traverse_alter.go
@@ -76,6 +76,31 @@ func (c *TraverseAlterTableDropColsOrIndexes) Leave(in ast.Node) (ast.Node, bool
 	return in, true
 }
 
+// TraverseAlterTableDropTiDBColWithCoveredIndex
+type TraverseAlterTableDropTiDBColWithCoveredIndex struct {
+	Table   string   // 表名
+	IsMatch int      // 是否匹配当前规则
+	Cols    []string // 列
+}
+
+func (c *TraverseAlterTableDropTiDBColWithCoveredIndex) Enter(in ast.Node) (ast.Node, bool) {
+	if stmt, ok := in.(*ast.AlterTableStmt); ok {
+		c.Table = stmt.Table.Name.String()
+		for _, spec := range stmt.Specs {
+			switch spec.Tp {
+			case ast.AlterTableDropColumn:
+				c.IsMatch++
+				c.Cols = append(c.Cols, spec.OldColumnName.Name.O)
+			}
+		}
+	}
+	return in, false
+}
+
+func (c *TraverseAlterTableDropTiDBColWithCoveredIndex) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
+}
+
 // TraverseAlterTableOptions
 type TraverseAlterTableOptions struct {
 	IsMatch int // 是否匹配当前规则


### PR DESCRIPTION
由于TiDB目前不支持删除主键列或组合索引相关列，增加删除tidb列覆盖索引是否包含此列的检查
