### PR TITLE
优化列类型和默认值类型判断

### DIFF
--- a/controllers/process/column.go
+++ b/controllers/process/column.go
@@ -165,8 +165,13 @@ func (c *ColOptions) CheckColumnDefaultValue() error {
 				}
 			}
 		case mysql.TypeVarchar, mysql.TypeString:
+			var defaultStr string
+			defaultStr, ok := c.DefaultValue.(string)
+			if !ok {
+				return fmt.Errorf("列`%s`的默认值类型应为字符串但获取到其他类型[表`%s`]", c.Column, c.Table)
+			}
 			// 判断string型默认值的长度是否超过了定义的长度
-			if utf8.RuneCountInString(c.DefaultValue.(string)) > c.Flen {
+			if utf8.RuneCountInString(defaultStr) > c.Flen {
 				return fmt.Errorf("列`%s`的默认值超过了字段类型定义的长度[表`%s`]", c.Column, c.Table)
 			}
 		}


### PR DESCRIPTION
当修改的列类型为 varchar，默认值类型为 int 的时候，服务会报错 500。

错误：
```
alter table test modify column c1 varchar(10) default 0
```
正确：
```
alter table test modify column c1 varchar(10) default '0'
```